### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/cbcd215d-6456-41d4-8355-fd4c664a8fb9/a2f64adf-e76f-45e3-bbd9-c98dca802207/_apis/work/boardbadge/60df288c-9aaa-461c-b1bb-f3a7b1d3de6d)](https://dev.azure.com/aiw-devops/cbcd215d-6456-41d4-8355-fd4c664a8fb9/_boards/board/t/a2f64adf-e76f-45e3-bbd9-c98dca802207/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#140. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.